### PR TITLE
Add support for Windows

### DIFF
--- a/crayons.py
+++ b/crayons.py
@@ -22,6 +22,7 @@ __all__ = (
     'clean', 'disable'
 )
 
+colorama.init()
 COLORS = __all__[:-2]
 
 if 'get_ipython' in dir():


### PR DESCRIPTION
I was using this on a Mac, and thought it was pretty great. Tried it on Windows earlier today and was pretty disappointed that it wasn't working, so I used colorama instead. 

It looks like adding just this one line will let people use this on Windows. I didn't do any super comprehensive testing, but I printed a red string, a black string and a normal string on Windows 7 in a command prompt window and in a powershell window, and it worked as expected.